### PR TITLE
Fixed README to show sortable column headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,7 @@ end
 You can then pass the query object as a parameter to the table presenter initializer, and associate table columns to specific sorting scopes of the query object using the `sorting` directive:
 
 ```erb
-<% query = present(@query) %>
-
-<%= table_for(@tasks, class: Task) do |row, record| %>
+<%= table_for(@tasks, class: Task, query: present(@query)) do |row, record| %>
   <%= row.column :title, sorting: :by_title %>
   <%= row.column :due_date, sorting: :by_due_date %>
 <% end %>


### PR DESCRIPTION
The readme did not show the query parameter being passed to the table.