### PR TITLE
filter_by for form inputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,7 @@ gemfile:
   - "gemfiles/rails_40.gemfile"
   - "gemfiles/rails_42.gemfile"
 
+before_install:
+  - gem install bundler
+
 script: "bundle exec rake spec"

--- a/lib/admino/query/base.rb
+++ b/lib/admino/query/base.rb
@@ -106,4 +106,3 @@ module Admino
     end
   end
 end
-

--- a/lib/admino/query/dsl.rb
+++ b/lib/admino/query/dsl.rb
@@ -15,6 +15,10 @@ module Admino
 
       def filter_by(name, scopes, options = {})
         config.add_filter_group(name, scopes, options)
+
+        define_method name do
+          filter_group_by_name(name).value.to_s
+        end
       end
 
       def sorting(*args)
@@ -32,4 +36,3 @@ module Admino
     end
   end
 end
-

--- a/lib/admino/query/filter_group.rb
+++ b/lib/admino/query/filter_group.rb
@@ -71,4 +71,3 @@ module Admino
     end
   end
 end
-

--- a/lib/admino/version.rb
+++ b/lib/admino/version.rb
@@ -1,4 +1,3 @@
 module Admino
-  VERSION = "0.0.15"
+  VERSION = "0.0.16"
 end
-


### PR DESCRIPTION
Now it's possible to use filter_by declaration in order to define form inputs with scopes without params